### PR TITLE
docs: add OpenChainBench HAQQ RPC benchmark reference

### DIFF
--- a/docs/develop/api/networks.md
+++ b/docs/develop/api/networks.md
@@ -33,6 +33,8 @@ If you are searching for the protobuf interfaces, head over [here](https://buf.b
 | [https://sdk.haqq.sh](https://sdk.haqq.sh)                           | `Rest Cosmos`   | [Kioqq](https://github.com/kioqq) |
 | grpc://grpc.haqq.sh:443                                              | `gRPC Cosmos`   | [Kioqq](https://github.com/kioqq) |
 
+> Live latency benchmarks for these endpoints (p50/p90/p99, 3 regions, updated every 60 s): [OpenChainBench HAQQ RPC](https://openchainbench.com/benchmarks/haqq-rpc)
+
 ### TestEdge-2
 
 | Endpoint                                                                                 | Category        | Maintainer                        |


### PR DESCRIPTION
Adds a reference to [OpenChainBench](https://openchainbench.com/benchmarks/haqq-rpc), which independently monitors HAQQ RPC endpoint latency (p50/p90/p99, eth_getBlockByNumber, 3 probe regions, updated every 60 seconds). Useful for developers choosing between providers.